### PR TITLE
Support specifying a specific vcpkg revision.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
           pkgs: boost-date-time
           triplet: ${{ matrix.config.vcpkg_triplet }}
           cache-key: ${{ matrix.config.os }}
+          revision: master
       - name: tree
         if: runner.os == 'Windows'
         shell: cmd

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Simple usage example:
     # Additional string to add to cache key. If using a build matrix or building different configurations
     # on the same operating system, be sure to include an additional cache key to separate the caches. (optional)
     cache-key: ''
+    # vcpkg revision to checkout
+    # A valid git ref; if empty, it defaults to the latest vcpkg stable release.
+    revision: ''
 
 ```
 
@@ -71,5 +74,6 @@ jobs:
           pkgs: boost-date-time
           triplet: ${{ matrix.config.vcpkg_triplet }}
           cache-key: ${{ matrix.config.os }}
+          revision: master
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -17,15 +17,35 @@ inputs:
     description: "Disable cache (useful for release builds)"
     required: false
     default: 'false'
+  revision:
+    description: "vcpkg revision to checkout."
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
+  - name: Get latest Github release
+    uses: pozetroninc/github-action-get-latest-release@v0.6.0
+    id: get-latest-vcpkg-release
+    with:
+      repository: microsoft/vcpkg
+      excludes: prerelease, draft
+  - name: Determine checkout tag
+    shell: bash
+    id: determine-checkout-revision
+    run: |
+      if [[ "${{ inputs.revision }}" != "" ]]; then
+        echo "::set-output name=vcpkg-revision::${{ inputs.revision }}"
+      else
+        echo "::set-output name=vcpkg-revision::${{ steps.get-latest-vcpkg-release.outputs.release }}"
+      fi
   - name: checkout-vcpkg
     uses: actions/checkout@v3
     with:
       path: ${{ github.workspace }}/vcpkg
       repository: microsoft/vcpkg
-      fetch-depth: 1
+      ref: '${{ steps.determine-checkout-revision.outputs.vcpkg-revision }}'
+      fetch-depth: 1 
   - name: bootstrap-vcpkg-win
     if: runner.os == 'Windows'
     working-directory: ${{ github.workspace }}\vcpkg


### PR DESCRIPTION
As detailed in #1, I was struggling with a botched update to boost in vcpkg's master branch, so I went ahead and added the possibility to allow checking out a specific version of vcpkg, rather than always just the latest.