### PR TITLE
Fix missing cache-key extra arg

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,7 +92,7 @@ runs:
     uses: pat-s/always-upload-cache@v3
     with:
       path: ${{ github.workspace }}/vcpkg_cache
-      key: ${{ runner.os }}-${{ inputs.triplet }}-vcpkg-${{ hashFiles('vcpkg/vcpkg_dry_run.txt') }}
+      key: ${{ runner.os }}-${{ inputs.triplet }}-vcpkg-${{ hashFiles('vcpkg/vcpkg_dry_run.txt') }}-${{ inputs.cache-key }}
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: build-vcpkg-win


### PR DESCRIPTION
The cache-key input was omitted from the cache-vcpkg-archives step key parameter. This PR corrects this omision. 