### PR TITLE
Use cardinalby/git-get-release-action@v1 action with GitHub token to avoid rate limit problem

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,3 +32,29 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: tree
+
+  test-latest-vcpkg-release:
+    runs-on: ${{ matrix.config.os }}
+    name: test-vcpkg-action-latest-vcpkg-release
+    strategy:
+      matrix:
+        config:
+        - os: ubuntu-20.04
+          vcpkg_triplet: x64-linux-release
+        - os: macos-11
+          vcpkg_triplet: x64-osx-release
+        - os: windows-2019
+          vcpkg_triplet: x64-windows-release
+    steps:
+      - uses: actions/checkout@v3
+      - name: vcpkg build
+        uses: ./
+        with:
+          pkgs: boost-date-time
+          triplet: ${{ matrix.config.vcpkg_triplet }}
+          cache-key: ${{ matrix.config.os }}
+          token: ${{ github.token }}
+      - name: tree
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: tree

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
           triplet: ${{ matrix.config.vcpkg_triplet }}
           cache-key: ${{ matrix.config.os }}
           revision: master
+          token: ${{ github.token }}
       - name: tree
         if: runner.os == 'Windows'
         shell: cmd

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Simple usage example:
   with:
     pkgs: boost-date-time boost-system
     triplet: x64-windows-release
+    token: ${{ github.token }}
 ```
 
 ## Usage
@@ -46,6 +47,9 @@ Simple usage example:
     # vcpkg revision to checkout
     # A valid git ref; if empty, it defaults to the latest vcpkg stable release.
     revision: ''
+    # GitHub token to authenticate API requests. This is necessary to determine vcpkg version to checkout
+    # Recommended to use ${{ github.token }}
+    token: ''
 
 ```
 
@@ -75,5 +79,6 @@ jobs:
           triplet: ${{ matrix.config.vcpkg_triplet }}
           cache-key: ${{ matrix.config.os }}
           revision: master
+          token: ${{ github.token }}
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -44,9 +44,9 @@ runs:
     id: determine-checkout-revision
     run: |
       if [[ "${{ inputs.revision }}" != "" ]]; then
-        echo "::set-output name=vcpkg-revision::${{ inputs.revision }}"
+        echo "vcpkg-revision=${{ inputs.revision }}" >> $GITHUB_STATE
       else
-        echo "::set-output name=vcpkg-revision::${{ steps.get-latest-vcpkg-release.outputs.tag_name }}"
+        echo "vcpkg-revision=${{ steps.get-latest-vcpkg-release.outputs.tag_name }}" >> $GITHUB_STATE
       fi
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"

--- a/action.yml
+++ b/action.yml
@@ -44,9 +44,9 @@ runs:
     id: determine-checkout-revision
     run: |
       if [[ "${{ inputs.revision }}" != "" ]]; then
-        echo "vcpkg-revision=${{ inputs.revision }}" >> $GITHUB_STATE
+        echo "vcpkg-revision=${{ inputs.revision }}" >> $GITHUB_OUTPUT
       else
-        echo "vcpkg-revision=${{ steps.get-latest-vcpkg-release.outputs.tag_name }}" >> $GITHUB_STATE
+        echo "vcpkg-revision=${{ steps.get-latest-vcpkg-release.outputs.tag_name }}" >> $GITHUB_OUTPUT
       fi
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
     default: ''
   token:
-    description: "GitHub token to authenticate API requests. Recommended to use ${{ github.token }}"
+    description: "GitHub token to authenticate API requests. Recommended to use  github.token "
     required: false
     default: ''
 runs:

--- a/action.yml
+++ b/action.yml
@@ -21,17 +21,24 @@ inputs:
     description: "vcpkg revision to checkout."
     required: false
     default: ''
+  token:
+    description: "GitHub token to authenticate API requests. Recommended to use ${{ github.token }}"
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
   - name: Get latest Github release
-    uses: pozetroninc/github-action-get-latest-release@v0.6.0
+    uses: cardinalby/git-get-release-action@v1
     id: get-latest-vcpkg-release
-    with:
-      repository: microsoft/vcpkg
-      excludes: prerelease, draft
     env:
+      GITHUB_TOKEN: ${{ inputs.token }}
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
+    with:
+      latest: true
+      repo: microsoft/vcpkg
+      prerelease: false
+      draft: false    
   - name: Determine checkout tag
     shell: bash
     id: determine-checkout-revision
@@ -39,7 +46,7 @@ runs:
       if [[ "${{ inputs.revision }}" != "" ]]; then
         echo "::set-output name=vcpkg-revision::${{ inputs.revision }}"
       else
-        echo "::set-output name=vcpkg-revision::${{ steps.get-latest-vcpkg-release.outputs.release }}"
+        echo "::set-output name=vcpkg-revision::${{ steps.get-latest-vcpkg-release.outputs.tag_name }}"
       fi
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"


### PR DESCRIPTION
The previous  pozetroninc/github-action-get-latest-release action did not take a GitHub token and was frequently receiving a rate limit error when trying to read the latest release. Use cardinalby/git-get-release-action@v1 instead that can take a GitHub token.