### PR TITLE
Add vcpkg-cmake-config output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: vcpkg build
+        id: vcpkg
         uses: ./
         with:
           pkgs: boost-date-time
@@ -34,9 +35,7 @@ jobs:
         run: tree
       - name: cmake configure
         run: >
-          cmake -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake 
-          -DVCPKG_TARGET_TRIPLET=${{ matrix.config.vcpkg_triplet }} -DVCPKG_MANIFEST_MODE=OFF
-          -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 
+          cmake ${{ steps.vcpkg.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 
 
   test-latest-vcpkg-release:
     runs-on: ${{ matrix.config.os }}
@@ -53,6 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: vcpkg build
+        id: vcpkg
         uses: ./
         with:
           pkgs: boost-date-time
@@ -65,9 +65,7 @@ jobs:
         run: tree
       - name: cmake configure
         run: >
-          cmake -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake 
-          -DVCPKG_TARGET_TRIPLET=${{ matrix.config.vcpkg_triplet }} -DVCPKG_MANIFEST_MODE=OFF
-          -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 
+          cmake ${{ steps.vcpkg.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 
 
   test-manifest:
     runs-on: ${{ matrix.config.os }}
@@ -84,6 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: vcpkg build
+        id: vcpkg
         uses: ./
         with:
           triplet: ${{ matrix.config.vcpkg_triplet }}
@@ -92,6 +91,4 @@ jobs:
           manifest-dir: ${{ github.workspace }}/.github/manifest
       - name: cmake configure
         run: >
-          cmake -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake 
-          -DVCPKG_TARGET_TRIPLET=${{ matrix.config.vcpkg_triplet }} -DVCPKG_MANIFEST_MODE=OFF
-          -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 
+          cmake ${{ steps.vcpkg.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         run: tree
       - name: cmake configure
         run: >
-          cmake ${{ steps.vcpkg.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 
+          cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 
 
   test-latest-vcpkg-release:
     runs-on: ${{ matrix.config.os }}
@@ -65,7 +65,7 @@ jobs:
         run: tree
       - name: cmake configure
         run: >
-          cmake ${{ steps.vcpkg.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 
+          cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 
 
   test-manifest:
     runs-on: ${{ matrix.config.os }}
@@ -91,4 +91,4 @@ jobs:
           manifest-dir: ${{ github.workspace }}/.github/manifest
       - name: cmake configure
         run: >
-          cmake ${{ steps.vcpkg.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 
+          cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ features:
  -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=<triplet> -DVCPKG_MANIFEST_MODE=OFF
 ```
 
+An output `vcpkg-cmake-config` is also created to simplify setting cmake configuration settings. Example usage:
+
+```
+cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S <src_dir> -B <build_dir>
+```
+
+Include other configuration settings as normal in the cmake command. The vcpkg-action step must have the id `vcpkg`.
+
 Another directory named `vcpkg_cache` is created in the workspace root. This directory is used to store the cache files, 
 and is cached using `pat-s/always-upload-cache@v3`. The cache key is automatically generated, 
 but can also be modified using the `cache-key` argument.
@@ -24,6 +32,7 @@ Simple usage example:
 ```yaml
 - name: vcpkg build
   uses: johnwason/vcpkg-action@v3
+  id: vcpkg
   with:
     pkgs: boost-date-time boost-system
     triplet: x64-windows-release
@@ -34,6 +43,7 @@ Simple manifest example:
 
 ```yaml
 - name: vcpkg build
+  id: vcpkg
   uses: johnwason/vcpkg-action@v3
   with:
     manifest-dir: ${{ github.workspace }} # Set to directory containing vcpkg.json
@@ -89,6 +99,7 @@ jobs:
     steps:
       - name: vcpkg build
         uses: johnwason/vcpkg-action@v3
+        id: vcpkg
         with:
           pkgs: boost-date-time
           triplet: ${{ matrix.config.vcpkg_triplet }}

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Directory containing vcpkg.json manifest file. Cannot be used with pkgs.
     required: false
     default: ''
+outputs:
+  vcpkg-cmake-config:
+    description: Configure options for cmake to use vcpkg
+    value: ${{ steps.vcpkg-cmake-config.outputs.cmake-config }}
 runs:
   using: "composite"
   steps:
@@ -162,3 +166,8 @@ runs:
       "${{ github.workspace }}/vcpkg/vcpkg" install --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} --x-manifest-root=${{ inputs.manifest-dir }} --x-install-root=${{ github.workspace }}/vcpkg/installed
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
+  - name: vcpkg cmake configure 
+    shell: bash
+    id: vcpkg-cmake-config
+    run: |
+      echo "vcpkg-cmake-config=-DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ matrix.config.vcpkg_triplet }} -DVCPKG_MANIFEST_MODE=OFF" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
 outputs:
   vcpkg-cmake-config:
     description: Configure options for cmake to use vcpkg
-    value: ${{ steps.vcpkg-cmake-config.outputs.cmake-config }}
+    value: ${{ steps.vcpkg-cmake-config.outputs.vcpkg-cmake-config }}
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Adds a `vcpkg-cmake-config` action output containing the required cmake config settings to use vcpkg.