### PR TITLE
Add vcpkg-cache-hash output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ outputs:
   vcpkg-cmake-config:
     description: Configure options for cmake to use vcpkg
     value: ${{ steps.vcpkg-cmake-config.outputs.vcpkg-cmake-config }}
+  vcpkg-cache-hash:
+    description: Hash of the vcpkg cache key
+    value: ${{ steps.vcpkg-cmake-config.outputs.vcpkg-cache-hash }}
 runs:
   using: "composite"
   steps:
@@ -172,4 +175,3 @@ runs:
     run: |
       echo "vcpkg-cmake-config=-DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ inputs.triplet }} -DVCPKG_MANIFEST_MODE=OFF" >> $GITHUB_OUTPUT
       echo "vcpkg-cache-hash=${{ hashFiles('vcpkg/vcpkg_dry_run.txt') }}-${{ inputs.cache-key }}" >> $GITHUB_OUTPUT
-      

--- a/action.yml
+++ b/action.yml
@@ -171,3 +171,5 @@ runs:
     id: vcpkg-cmake-config
     run: |
       echo "vcpkg-cmake-config=-DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ inputs.triplet }} -DVCPKG_MANIFEST_MODE=OFF" >> $GITHUB_OUTPUT
+      echo "vcpkg-cache-hash=${{ hashFiles('vcpkg/vcpkg_dry_run.txt') }}-${{ inputs.cache-key }}" >> $GITHUB_OUTPUT
+      


### PR DESCRIPTION
This PR adds a `vcpkg-cache-hash` output that contains the hash combined with `cache-key` input of the current vcpkg cache. This can be passed to other cache steps, such as the main build cache, to keep them updated if the vcpkg build changes.