### PR TITLE
Add github-binarycache option to use built in cache

### DIFF
--- a/.github/workflows/clear_cache.yml
+++ b/.github/workflows/clear_cache.yml
@@ -1,0 +1,12 @@
+name: Clear all Github actions caches 
+on:
+  workflow_dispatch:
+
+jobs:
+  my-job:
+    name: Delete all caches
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Clear caches
+        uses: easimon/wipe-cache@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,22 @@ jobs:
         config:
         - os: ubuntu-20.04
           vcpkg_triplet: x64-linux-release
+          github-binarycache: false
         - os: macos-11
           vcpkg_triplet: x64-osx-release
+          github-binarycache: false
         - os: windows-2019
           vcpkg_triplet: x64-windows-release
+          github-binarycache: false
+        - os: ubuntu-20.04
+          vcpkg_triplet: x64-linux-release
+          github-binarycache: true
+        - os: macos-11
+          vcpkg_triplet: x64-osx-release
+          github-binarycache: true
+        - os: windows-2019
+          vcpkg_triplet: x64-windows-release
+          github-binarycache: true
     steps:
       - uses: actions/checkout@v3
       - name: vcpkg build
@@ -29,6 +41,7 @@ jobs:
           cache-key: ${{ matrix.config.os }}
           revision: master
           token: ${{ github.token }}
+          github-binarycache: ${{ matrix.config.github-binarycache }}
       - name: tree
         if: runner.os == 'Windows'
         shell: cmd
@@ -45,10 +58,22 @@ jobs:
         config:
         - os: ubuntu-20.04
           vcpkg_triplet: x64-linux-release
+          github-binarycache: false
         - os: macos-11
           vcpkg_triplet: x64-osx-release
+          github-binarycache: false
         - os: windows-2019
           vcpkg_triplet: x64-windows-release
+          github-binarycache: false
+        - os: ubuntu-20.04
+          vcpkg_triplet: x64-linux-release
+          github-binarycache: true
+        - os: macos-11
+          vcpkg_triplet: x64-osx-release
+          github-binarycache: true
+        - os: windows-2019
+          vcpkg_triplet: x64-windows-release
+          github-binarycache: true
     steps:
       - uses: actions/checkout@v3
       - name: vcpkg build
@@ -59,6 +84,7 @@ jobs:
           triplet: ${{ matrix.config.vcpkg_triplet }}
           cache-key: ${{ matrix.config.os }}
           token: ${{ github.token }}
+          github-binarycache: ${{ matrix.config.github-binarycache }}
       - name: tree
         if: runner.os == 'Windows'
         shell: cmd
@@ -75,10 +101,22 @@ jobs:
         config:
         - os: ubuntu-20.04
           vcpkg_triplet: x64-linux-release
+          github-binarycache: false
         - os: macos-11
           vcpkg_triplet: x64-osx-release
+          github-binarycache: false
         - os: windows-2019
           vcpkg_triplet: x64-windows-release
+          github-binarycache: false
+        - os: ubuntu-20.04
+          vcpkg_triplet: x64-linux-release
+          github-binarycache: true
+        - os: macos-11
+          vcpkg_triplet: x64-osx-release
+          github-binarycache: true
+        - os: windows-2019
+          vcpkg_triplet: x64-windows-release
+          github-binarycache: true
     steps:
       - uses: actions/checkout@v3
       - name: vcpkg build
@@ -89,6 +127,7 @@ jobs:
           cache-key: ${{ matrix.config.os }}
           token: ${{ github.token }}
           manifest-dir: ${{ github.workspace }}/.github/manifest
+          github-binarycache: ${{ matrix.config.github-binarycache }}
       - name: cmake configure
         run: >
-          cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 
+          cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
     name: test-vcpkg-action
     strategy:
+      fail-fast: false
       matrix:
         config:
         - os: ubuntu-20.04
@@ -54,6 +55,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
     name: test-vcpkg-action-latest-vcpkg-release
     strategy:
+      fail-fast: false
       matrix:
         config:
         - os: ubuntu-20.04
@@ -97,6 +99,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
     name: test-manifest
     strategy:
+      fail-fast: false
       matrix:
         config:
         - os: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 features:
 
 * Simplicity
-* Use of a "dry-run" build to generate a unique cache key for the configuration. This guarantees that if packages
-  change, the cache will be rebuilt, but avoids rebuilding when it isn't necessary.
+* Uses vcpkg built-in GitHub caching feature (NEW) OR Use of a "dry-run" build to generate a unique cache key for the configuration. 
 * Optionally supports reading `vcpkg.json` manifest files
 
 `vcpkg` is cloned to the `${{ github.workspace }}\vcpkg` directory, and the build products are located in
@@ -37,6 +36,7 @@ Simple usage example:
     pkgs: boost-date-time boost-system
     triplet: x64-windows-release
     token: ${{ github.token }}
+    github-binarycache: true
 ```
 
 Simple manifest example:
@@ -49,6 +49,7 @@ Simple manifest example:
     manifest-dir: ${{ github.workspace }} # Set to directory containing vcpkg.json
     triplet: x64-windows-release
     token: ${{ github.token }}
+    github-binarycache: true
 ```
 
 
@@ -75,6 +76,9 @@ Simple manifest example:
     token: ''
     # Directory containing vcpkg.json manifest file. Cannot be used with pkgs.
     manifest-dir: ''
+    github-binarycache: ''
+    # "Use vcpkg built-in GitHub binary caching if "true". If not specified, will use the dry-run based file cache."
+    # Recommended set to "true"
 
 ```
 
@@ -106,5 +110,6 @@ jobs:
           cache-key: ${{ matrix.config.os }}
           revision: master
           token: ${{ github.token }}
+          github-binarycache: true
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -90,16 +90,15 @@ runs:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: set-binarycache-variable
     if: inputs.github-binarycache != 'true' && inputs.github-binarycache != true
-    uses: actions/github-script@v6
-    with:
-      script: |       
-          core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', "${{ github.workspace }}/vcpkg_cache");
+    shell: bash
+    run: |
+      echo VCPKG_DEFAULT_BINARY_CACHE='${{ github.workspace }}/vcpkg_cache' >> $GITHUB_ENV
+      mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
   - name: vcpkg-dry-run-win
     if: runner.os == 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
     working-directory: ${{ github.workspace }}\vcpkg
     shell: powershell
     run: |
-      mkdir -Force $Env:VCPKG_DEFAULT_BINARY_CACHE
       & "${{ github.workspace }}/vcpkg/vcpkg.exe" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} ${{ inputs.pkgs }} | Tee-Object -FilePath vcpkg_dry_run.txt
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
@@ -108,7 +107,6 @@ runs:
     working-directory: ${{ github.workspace }}/vcpkg
     shell: bash
     run: |
-      mkdir $VCPKG_DEFAULT_BINARY_CACHE
       "${{ github.workspace }}/vcpkg/vcpkg" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} ${{ inputs.pkgs }} | tee vcpkg_dry_run.txt
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
@@ -117,7 +115,6 @@ runs:
     working-directory: ${{ github.workspace }}\vcpkg
     shell: powershell
     run: |
-      mkdir -Force $Env:VCPKG_DEFAULT_BINARY_CACHE
       & "${{ github.workspace }}/vcpkg/vcpkg.exe" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} --x-manifest-root=${{ inputs.manifest-dir }} --x-install-root=${{ github.workspace }}\vcpkg\installed | Tee-Object -FilePath vcpkg_dry_run.txt
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
@@ -126,7 +123,6 @@ runs:
     working-directory: ${{ github.workspace }}/vcpkg
     shell: bash
     run: |
-      mkdir $VCPKG_DEFAULT_BINARY_CACHE
       "${{ github.workspace }}/vcpkg/vcpkg" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} --x-manifest-root=${{ inputs.manifest-dir }} --x-install-root=${{ github.workspace }}/vcpkg/installed | tee vcpkg_dry_run.txt
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Directory containing vcpkg.json manifest file. Cannot be used with pkgs.
     required: false
     default: ''
+  github-binarycache:
+    description: "GitHub binary cache to use. If not specified, will use the dry-run based file cache."
+    required: false
+    default: 'false'
 outputs:
   vcpkg-cmake-config:
     description: Configure options for cmake to use vcpkg
@@ -85,7 +89,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: vcpkg-dry-run-win
-    if: runner.os == 'Windows' && inputs.manifest-dir == ''
+    if: runner.os == 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache == 'false'
     working-directory: ${{ github.workspace }}\vcpkg
     shell: powershell
     run: |
@@ -95,7 +99,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: vcpkg-dry-run-unix
-    if: runner.os != 'Windows' && inputs.manifest-dir == ''
+    if: runner.os != 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache == 'false'
     working-directory: ${{ github.workspace }}/vcpkg
     shell: bash
     run: |
@@ -105,7 +109,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: vcpkg-dry-run-win-manifest
-    if: runner.os == 'Windows' && inputs.manifest-dir != ''
+    if: runner.os == 'Windows' && inputs.manifest-dir != '' && inputs.github-binarycache == 'false'
     working-directory: ${{ github.workspace }}\vcpkg
     shell: powershell
     run: |
@@ -115,7 +119,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: vcpkg-dry-run-unix-manifest
-    if: runner.os != 'Windows' && inputs.manifest-dir != ''
+    if: runner.os != 'Windows' && inputs.manifest-dir != '' && inputs.github-binarycache == 'false'
     working-directory: ${{ github.workspace }}/vcpkg
     shell: bash
     run: |
@@ -125,7 +129,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: cache-vcpkg-archives
-    if: ${{ inputs.disable_cache != 'true' }}
+    if: ${{ inputs.disable_cache != 'true' }} && inputs.github-binarycache == 'false'
     id: cache-vcpkg-archives
     uses: pat-s/always-upload-cache@v3
     with:
@@ -133,6 +137,14 @@ runs:
       key: ${{ runner.os }}-${{ inputs.triplet }}-vcpkg-${{ hashFiles('vcpkg/vcpkg_dry_run.txt') }}-${{ inputs.cache-key }}
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
+  - name: Export GitHub Actions cache environment variables
+    if:   inputs.github-binarycache != 'false'
+    uses: actions/github-script@v6
+    with:
+      script: |
+        core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+        core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+        core.exportVariable('VCPKG_BINARY_SOURCES', "clear;x-gha,readwrite");
   - name: build-vcpkg-win
     if: runner.os == 'Windows' && inputs.manifest-dir == ''
     shell: cmd

--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: vcpkg-dry-run-unix
-    if: runner.os != 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache != 'true' inputs.github-binarycache != true
+    if: runner.os != 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
     working-directory: ${{ github.workspace }}/vcpkg
     shell: bash
     run: |

--- a/action.yml
+++ b/action.yml
@@ -103,7 +103,7 @@ runs:
     working-directory: ${{ github.workspace }}\vcpkg
     shell: powershell
     run: |
-      mkdir $Env:VCPKG_DEFAULT_BINARY_CACHE
+      mkdir -Force $Env:VCPKG_DEFAULT_BINARY_CACHE
       & "${{ github.workspace }}/vcpkg/vcpkg.exe" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} ${{ inputs.pkgs }} | Tee-Object -FilePath vcpkg_dry_run.txt
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
@@ -121,7 +121,7 @@ runs:
     working-directory: ${{ github.workspace }}\vcpkg
     shell: powershell
     run: |
-      mkdir $Env:VCPKG_DEFAULT_BINARY_CACHE
+      mkdir -Force $Env:VCPKG_DEFAULT_BINARY_CACHE
       & "${{ github.workspace }}/vcpkg/vcpkg.exe" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} --x-manifest-root=${{ inputs.manifest-dir }} --x-install-root=${{ github.workspace }}\vcpkg\installed | Tee-Object -FilePath vcpkg_dry_run.txt
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ runs:
     with:
       script: |
         if (process.platform == 'win32') {
-          core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', "${{ github.workspace }}\\vcpkg_cache");
+          core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', "${{ github.workspace }}\\\\vcpkg_cache");
         } else {
           core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', "${{ github.workspace }}/vcpkg_cache");
         }

--- a/action.yml
+++ b/action.yml
@@ -99,7 +99,7 @@ runs:
     working-directory: ${{ github.workspace }}\vcpkg
     shell: powershell
     run: |
-      mkdir $Env::VCPKG_DEFAULT_BINARY_CACHE
+      mkdir $Env:VCPKG_DEFAULT_BINARY_CACHE
       & "${{ github.workspace }}/vcpkg/vcpkg.exe" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} ${{ inputs.pkgs }} | Tee-Object -FilePath vcpkg_dry_run.txt
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
@@ -117,7 +117,7 @@ runs:
     working-directory: ${{ github.workspace }}\vcpkg
     shell: powershell
     run: |
-      mkdir $Env::VCPKG_DEFAULT_BINARY_CACHE
+      mkdir $Env:VCPKG_DEFAULT_BINARY_CACHE
       & "${{ github.workspace }}/vcpkg/vcpkg.exe" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} --x-manifest-root=${{ inputs.manifest-dir }} --x-install-root=${{ github.workspace }}\vcpkg\installed | Tee-Object -FilePath vcpkg_dry_run.txt
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: ''
   github-binarycache:
-    description: "GitHub binary cache to use. If not specified, will use the dry-run based file cache."
+    description: "Use vcpkg built-in GitHub binary caching. If not specified, will use the dry-run based file cache."
     required: false
     default: ''
 outputs:
@@ -136,7 +136,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: Export GitHub Actions cache environment variables
-    if:   inputs.github-binarycache != 'false'
+    if:   inputs.github-binarycache == 'true' || inputs.github-binarycache == true
     uses: actions/github-script@v6
     with:
       script: |

--- a/action.yml
+++ b/action.yml
@@ -117,7 +117,7 @@ runs:
     working-directory: ${{ github.workspace }}\vcpkg
     shell: powershell
     run: |
-      mkdir $VCPKG_DEFAULT_BINARY_CACHE
+      mkdir $Env::VCPKG_DEFAULT_BINARY_CACHE
       & "${{ github.workspace }}/vcpkg/vcpkg.exe" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} --x-manifest-root=${{ inputs.manifest-dir }} --x-install-root=${{ github.workspace }}\vcpkg\installed | Tee-Object -FilePath vcpkg_dry_run.txt
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"

--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: set-binarycache-variable
-    if: inputs.gitlab-binarycache != 'true' && inputs.gitlab-binarycache != true
+    if: inputs.github-binarycache != 'true' && inputs.github-binarycache != true
     uses: actions/github-script@v6
     with:
       script: |

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
     uses: actions/github-script@v6
     with:
       script: |
-        core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', "${{ github.workspace }}\vcpkg_cache");
+        core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', "${{ github.workspace }}/vcpkg_cache");
   - name: vcpkg-dry-run-win
     if: runner.os == 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
     working-directory: ${{ github.workspace }}\vcpkg

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,7 @@ runs:
     shell: bash
     run: |
       echo VCPKG_DEFAULT_BINARY_CACHE='${{ github.workspace }}/vcpkg_cache' >> $GITHUB_ENV
-      mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
+      mkdir -p '${{ github.workspace }}/vcpkg_cache'
   - name: vcpkg-dry-run-win
     if: runner.os == 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
     working-directory: ${{ github.workspace }}\vcpkg

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,11 @@ runs:
     uses: actions/github-script@v6
     with:
       script: |
-        core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', "${{ github.workspace }}/vcpkg_cache");
+        if (process.platform == 'win32') {
+          core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', "${{ github.workspace }}\\vcpkg_cache");
+        } else {
+          core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', "${{ github.workspace }}/vcpkg_cache");
+        }
   - name: vcpkg-dry-run-win
     if: runner.os == 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
     working-directory: ${{ github.workspace }}\vcpkg

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
   github-binarycache:
     description: "GitHub binary cache to use. If not specified, will use the dry-run based file cache."
     required: false
-    default: 'false'
+    default: ''
 outputs:
   vcpkg-cmake-config:
     description: Configure options for cmake to use vcpkg
@@ -89,13 +89,13 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: set-binarycache-variable
-    if: inputs.gitlab-binarycache == 'false'
+    if: inputs.gitlab-binarycache != 'true'
     uses: actions/github-script@v6
     with:
       script: |
         core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', "${{ github.workspace }}\vcpkg_cache");
   - name: vcpkg-dry-run-win
-    if: runner.os == 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache == 'false'
+    if: runner.os == 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache != 'true'
     working-directory: ${{ github.workspace }}\vcpkg
     shell: powershell
     run: |
@@ -104,7 +104,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: vcpkg-dry-run-unix
-    if: runner.os != 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache == 'false'
+    if: runner.os != 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache != 'true'
     working-directory: ${{ github.workspace }}/vcpkg
     shell: bash
     run: |
@@ -113,7 +113,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: vcpkg-dry-run-win-manifest
-    if: runner.os == 'Windows' && inputs.manifest-dir != '' && inputs.github-binarycache == 'false'
+    if: runner.os == 'Windows' && inputs.manifest-dir != '' && inputs.github-binarycache != 'true'
     working-directory: ${{ github.workspace }}\vcpkg
     shell: powershell
     run: |
@@ -122,7 +122,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: vcpkg-dry-run-unix-manifest
-    if: runner.os != 'Windows' && inputs.manifest-dir != '' && inputs.github-binarycache == 'false'
+    if: runner.os != 'Windows' && inputs.manifest-dir != '' && inputs.github-binarycache != 'true'
     working-directory: ${{ github.workspace }}/vcpkg
     shell: bash
     run: |
@@ -131,7 +131,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: cache-vcpkg-archives
-    if: ${{ inputs.disable_cache != 'true' }} && inputs.github-binarycache == 'false'
+    if: ${{ inputs.disable_cache != 'true' }} && inputs.github-binarycache != 'true'
     id: cache-vcpkg-archives
     uses: pat-s/always-upload-cache@v3
     with:

--- a/action.yml
+++ b/action.yml
@@ -88,13 +88,18 @@ runs:
     shell: bash
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
+  - name: set-binarycache-variable
+    if: inputs.gitlab-binarycache == 'false'
+    uses: actions/github-script@v6
+    with:
+      script: |
+        core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', "${{ github.workspace }}\vcpkg_cache");
   - name: vcpkg-dry-run-win
     if: runner.os == 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache == 'false'
     working-directory: ${{ github.workspace }}\vcpkg
     shell: powershell
     run: |
-      $VCPKG_DEFAULT_BINARY_CACHE = "${{ github.workspace }}\vcpkg_cache"
-      mkdir $VCPKG_DEFAULT_BINARY_CACHE
+      mkdir $Env::VCPKG_DEFAULT_BINARY_CACHE
       & "${{ github.workspace }}/vcpkg/vcpkg.exe" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} ${{ inputs.pkgs }} | Tee-Object -FilePath vcpkg_dry_run.txt
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
@@ -103,7 +108,6 @@ runs:
     working-directory: ${{ github.workspace }}/vcpkg
     shell: bash
     run: |
-      export VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg_cache
       mkdir $VCPKG_DEFAULT_BINARY_CACHE
       "${{ github.workspace }}/vcpkg/vcpkg" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} ${{ inputs.pkgs }} | tee vcpkg_dry_run.txt
     env:
@@ -113,7 +117,6 @@ runs:
     working-directory: ${{ github.workspace }}\vcpkg
     shell: powershell
     run: |
-      $VCPKG_DEFAULT_BINARY_CACHE = "${{ github.workspace }}\vcpkg_cache"
       mkdir $VCPKG_DEFAULT_BINARY_CACHE
       & "${{ github.workspace }}/vcpkg/vcpkg.exe" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} --x-manifest-root=${{ inputs.manifest-dir }} --x-install-root=${{ github.workspace }}\vcpkg\installed | Tee-Object -FilePath vcpkg_dry_run.txt
     env:
@@ -123,7 +126,6 @@ runs:
     working-directory: ${{ github.workspace }}/vcpkg
     shell: bash
     run: |
-      export VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg_cache
       mkdir $VCPKG_DEFAULT_BINARY_CACHE
       "${{ github.workspace }}/vcpkg/vcpkg" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} --x-manifest-root=${{ inputs.manifest-dir }} --x-install-root=${{ github.workspace }}/vcpkg/installed | tee vcpkg_dry_run.txt
     env:
@@ -150,7 +152,6 @@ runs:
     shell: cmd
     working-directory: ${{ github.workspace }}\vcpkg
     run: |
-      set VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}\vcpkg_cache
       "${{ github.workspace }}/vcpkg/vcpkg.exe" install --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} ${{ inputs.pkgs }}
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
@@ -159,7 +160,6 @@ runs:
     shell: bash
     working-directory: ${{ github.workspace }}/vcpkg
     run: |
-      export VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg_cache
       "${{ github.workspace }}/vcpkg/vcpkg" install --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} ${{ inputs.pkgs }}
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
@@ -168,7 +168,6 @@ runs:
     shell: cmd
     working-directory: ${{ github.workspace }}\vcpkg
     run: |
-      set VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}\vcpkg_cache
       "${{ github.workspace }}/vcpkg/vcpkg.exe" install --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} --x-manifest-root=${{ inputs.manifest-dir }} --x-install-root=${{ github.workspace }}/vcpkg/installed
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
@@ -177,7 +176,6 @@ runs:
     shell: bash
     working-directory: ${{ github.workspace }}/vcpkg
     run: |
-      export VCPKG_DEFAULT_BINARY_CACHE=${{ github.workspace }}/vcpkg_cache
       "${{ github.workspace }}/vcpkg/vcpkg" install --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} --x-manifest-root=${{ inputs.manifest-dir }} --x-install-root=${{ github.workspace }}/vcpkg/installed
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"

--- a/action.yml
+++ b/action.yml
@@ -92,12 +92,8 @@ runs:
     if: inputs.github-binarycache != 'true' && inputs.github-binarycache != true
     uses: actions/github-script@v6
     with:
-      script: |
-        if (process.platform == 'win32') {
-          core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', "${{ github.workspace }}\\\\vcpkg_cache");
-        } else {
+      script: |       
           core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', "${{ github.workspace }}/vcpkg_cache");
-        }
   - name: vcpkg-dry-run-win
     if: runner.os == 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
     working-directory: ${{ github.workspace }}\vcpkg

--- a/action.yml
+++ b/action.yml
@@ -89,13 +89,13 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: set-binarycache-variable
-    if: inputs.gitlab-binarycache != 'true'
+    if: inputs.gitlab-binarycache != 'true' && inputs.gitlab-binarycache != true
     uses: actions/github-script@v6
     with:
       script: |
         core.exportVariable('VCPKG_DEFAULT_BINARY_CACHE', "${{ github.workspace }}\vcpkg_cache");
   - name: vcpkg-dry-run-win
-    if: runner.os == 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache != 'true'
+    if: runner.os == 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
     working-directory: ${{ github.workspace }}\vcpkg
     shell: powershell
     run: |
@@ -104,7 +104,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: vcpkg-dry-run-unix
-    if: runner.os != 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache != 'true'
+    if: runner.os != 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache != 'true' inputs.github-binarycache != true
     working-directory: ${{ github.workspace }}/vcpkg
     shell: bash
     run: |
@@ -113,7 +113,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: vcpkg-dry-run-win-manifest
-    if: runner.os == 'Windows' && inputs.manifest-dir != '' && inputs.github-binarycache != 'true'
+    if: runner.os == 'Windows' && inputs.manifest-dir != '' && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
     working-directory: ${{ github.workspace }}\vcpkg
     shell: powershell
     run: |
@@ -122,7 +122,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: vcpkg-dry-run-unix-manifest
-    if: runner.os != 'Windows' && inputs.manifest-dir != '' && inputs.github-binarycache != 'true'
+    if: runner.os != 'Windows' && inputs.manifest-dir != '' && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
     working-directory: ${{ github.workspace }}/vcpkg
     shell: bash
     run: |
@@ -131,7 +131,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: cache-vcpkg-archives
-    if: ${{ inputs.disable_cache != 'true' }} && inputs.github-binarycache != 'true'
+    if: ${{ inputs.disable_cache != 'true' }} && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
     id: cache-vcpkg-archives
     uses: pat-s/always-upload-cache@v3
     with:


### PR DESCRIPTION
This pull requests adds a new option `github-binarycache` to use vcpkg's new built-in support for directly caching packages in the GitHub actions cache. This should be more reliable than the current dry-run based method. Set `github-binarycache: true` option to enable.

See https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-actions-cache