### PR TITLE
Add fetch-depth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ Simple manifest example:
     token: ''
     # Directory containing vcpkg.json manifest file. Cannot be used with pkgs.
     manifest-dir: ''
-    github-binarycache: ''
     # "Use vcpkg built-in GitHub binary caching if "true". If not specified, will use the dry-run based file cache."
     # Recommended set to "true"
+    github-binarycache: ''
+    #Fetch depth for vcpkg checkout. Defaults to "1"
+    fetch-depth: '1'
 
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: "Use vcpkg built-in GitHub binary caching. If not specified, will use the dry-run based file cache."
     required: false
     default: ''
+  fetch-depth:
+    description: "Fetch depth for vcpkg checkout"
+    required: false
+    default: "1"
 outputs:
   vcpkg-cmake-config:
     description: Configure options for cmake to use vcpkg
@@ -71,7 +75,7 @@ runs:
       path: ${{ github.workspace }}/vcpkg
       repository: microsoft/vcpkg
       ref: '${{ steps.determine-checkout-revision.outputs.vcpkg-revision }}'
-      fetch-depth: 1 
+      fetch-depth: ${{ inputs.fetch-depth }}
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: bootstrap-vcpkg-win


### PR DESCRIPTION
Add `fetch-depth` option to control the checkout depth when cloning vcpkg. Defaults to "1". Fixes #21