### PR TITLE
update checkout and script actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: checkout-vcpkg
-    uses: actions/checkout@v3
+    uses: actions/checkout@v4
     with:
       path: ${{ github.workspace }}/vcpkg
       repository: microsoft/vcpkg
@@ -141,7 +141,7 @@ runs:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
   - name: Export GitHub Actions cache environment variables
     if: (inputs.disable_cache != 'true' && inputs.disable_cache != true) &&  (inputs.github-binarycache == 'true' || inputs.github-binarycache == true)
-    uses: actions/github-script@v6
+    uses: actions/github-script@v7
     with:
       script: |
         core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');


### PR DESCRIPTION
To get ready for the node 20 switch

- update github/checkout to v4
- update github-script to v7