### PR TITLE
Use actions/cache instead of pat-s/always-upload-cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -133,7 +133,7 @@ runs:
   - name: cache-vcpkg-archives
     if: ${{ inputs.disable_cache != 'true' }} && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
     id: cache-vcpkg-archives
-    uses: pat-s/always-upload-cache@v3
+    uses: actions/cache@v4
     with:
       path: ${{ github.workspace }}/vcpkg_cache
       key: ${{ runner.os }}-${{ inputs.triplet }}-vcpkg-${{ hashFiles('vcpkg/vcpkg_dry_run.txt') }}-${{ inputs.cache-key }}


### PR DESCRIPTION
pat-s/always-upload-cache appears to be failing due to the API changes to the caching server.