### PR TITLE
Remove github-binarycache option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,22 +15,10 @@ jobs:
         config:
         - os: ubuntu-22.04
           vcpkg_triplet: x64-linux-release
-          github-binarycache: false
         - os: macos-13
           vcpkg_triplet: x64-osx-release
-          github-binarycache: false
         - os: windows-2022
           vcpkg_triplet: x64-windows-release
-          github-binarycache: false
-        - os: ubuntu-22.04
-          vcpkg_triplet: x64-linux-release
-          github-binarycache: true
-        - os: macos-13
-          vcpkg_triplet: x64-osx-release
-          github-binarycache: true
-        - os: windows-2022
-          vcpkg_triplet: x64-windows-release
-          github-binarycache: true
     steps:
       - uses: actions/checkout@v4
       - name: vcpkg build
@@ -39,10 +27,9 @@ jobs:
         with:
           pkgs: boost-date-time
           triplet: ${{ matrix.config.vcpkg_triplet }}
-          cache-key: ${{ matrix.config.os }}
+          cache-key: ${{ matrix.config.os }}-test
           revision: master
           token: ${{ github.token }}
-          github-binarycache: ${{ matrix.config.github-binarycache }}
       - name: tree
         if: runner.os == 'Windows'
         shell: cmd
@@ -60,22 +47,10 @@ jobs:
         config:
         - os: ubuntu-22.04
           vcpkg_triplet: x64-linux-release
-          github-binarycache: false
         - os: macos-13
           vcpkg_triplet: x64-osx-release
-          github-binarycache: false
         - os: windows-2022
           vcpkg_triplet: x64-windows-release
-          github-binarycache: false
-        - os: ubuntu-22.04
-          vcpkg_triplet: x64-linux-release
-          github-binarycache: true
-        - os: macos-13
-          vcpkg_triplet: x64-osx-release
-          github-binarycache: true
-        - os: windows-2022
-          vcpkg_triplet: x64-windows-release
-          github-binarycache: true
     steps:
       - uses: actions/checkout@v4
       - name: vcpkg build
@@ -84,9 +59,8 @@ jobs:
         with:
           pkgs: boost-date-time
           triplet: ${{ matrix.config.vcpkg_triplet }}
-          cache-key: ${{ matrix.config.os }}
+          cache-key: ${{ matrix.config.os }}-latest-vcpkg-release
           token: ${{ github.token }}
-          github-binarycache: ${{ matrix.config.github-binarycache }}
       - name: tree
         if: runner.os == 'Windows'
         shell: cmd
@@ -104,22 +78,10 @@ jobs:
         config:
         - os: ubuntu-22.04
           vcpkg_triplet: x64-linux-release
-          github-binarycache: false
         - os: macos-13
           vcpkg_triplet: x64-osx-release
-          github-binarycache: false
         - os: windows-2022
           vcpkg_triplet: x64-windows-release
-          github-binarycache: false
-        - os: ubuntu-22.04
-          vcpkg_triplet: x64-linux-release
-          github-binarycache: true
-        - os: macos-13
-          vcpkg_triplet: x64-osx-release
-          github-binarycache: true
-        - os: windows-2022
-          vcpkg_triplet: x64-windows-release
-          github-binarycache: true
     steps:
       - uses: actions/checkout@v4
       - name: vcpkg build
@@ -127,10 +89,9 @@ jobs:
         uses: ./
         with:
           triplet: ${{ matrix.config.vcpkg_triplet }}
-          cache-key: ${{ matrix.config.os }}
+          cache-key: ${{ matrix.config.os }}-manifest
           token: ${{ github.token }}
           manifest-dir: ${{ github.workspace }}/.github/manifest
-          github-binarycache: ${{ matrix.config.github-binarycache }}
       - name: cmake configure
         run: >
           cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S <src_dir> -B <build_dir>
 Include other configuration settings as normal in the cmake command. The vcpkg-action step must have the id `vcpkg`.
 
 Another directory named `vcpkg_cache` is created in the workspace root. This directory is used to store the cache files, 
-and is cached using `pat-s/always-upload-cache@v3`. The cache key is automatically generated, 
+and is cached using `actions/cache@v4`. The cache key is automatically generated, 
 but can also be modified using the `cache-key` argument.
 
 Simple usage example:
@@ -36,7 +36,6 @@ Simple usage example:
     pkgs: boost-date-time boost-system
     triplet: x64-windows-release
     token: ${{ github.token }}
-    github-binarycache: true
 ```
 
 Simple manifest example:
@@ -49,7 +48,6 @@ Simple manifest example:
     manifest-dir: ${{ github.workspace }} # Set to directory containing vcpkg.json
     triplet: x64-windows-release
     token: ${{ github.token }}
-    github-binarycache: true
     vcpkg-subdir: _vpk # a subdirectory of the action base folder into which the VCPKG will be installed. Default is 'vcpkg'.
 ```
 
@@ -77,9 +75,6 @@ Simple manifest example:
     token: ''
     # Directory containing vcpkg.json manifest file. Cannot be used with pkgs.
     manifest-dir: ''
-    # "Use vcpkg built-in GitHub binary caching if "true". If not specified, will use the dry-run based file cache."
-    # Recommended set to "true"
-    github-binarycache: ''
     #Fetch depth for vcpkg checkout. Defaults to "1"
     fetch-depth: '1'
 
@@ -113,6 +108,5 @@ jobs:
           cache-key: ${{ matrix.config.os }}
           revision: master
           token: ${{ github.token }}
-          github-binarycache: true
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -30,10 +30,6 @@ inputs:
     description: Directory containing vcpkg.json manifest file. Cannot be used with pkgs.
     required: false
     default: ''
-  github-binarycache:
-    description: "Use vcpkg built-in GitHub binary caching. If not specified, will use the dry-run based file cache."
-    required: false
-    default: ''
   fetch-depth:
     description: "Fetch depth for vcpkg checkout"
     required: false
@@ -99,13 +95,12 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}"
   - name: set-binarycache-variable
-    if: inputs.github-binarycache != 'true' && inputs.github-binarycache != true
     shell: bash
     run: |
       echo VCPKG_DEFAULT_BINARY_CACHE='${{ github.workspace }}/vcpkg_cache' >> $GITHUB_ENV
       mkdir -p '${{ github.workspace }}/vcpkg_cache'
   - name: vcpkg-dry-run-win
-    if: runner.os == 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
+    if: runner.os == 'Windows' && inputs.manifest-dir == ''
     working-directory: ${{ github.workspace }}\${{ inputs.vcpkg-subdir }}
     shell: powershell
     run: |
@@ -113,7 +108,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}"
   - name: vcpkg-dry-run-unix
-    if: runner.os != 'Windows' && inputs.manifest-dir == '' && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
+    if: runner.os != 'Windows' && inputs.manifest-dir == ''
     working-directory: ${{ github.workspace }}/${{ inputs.vcpkg-subdir }}
     shell: bash
     run: |
@@ -121,7 +116,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}"
   - name: vcpkg-dry-run-win-manifest
-    if: runner.os == 'Windows' && inputs.manifest-dir != '' && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
+    if: runner.os == 'Windows' && inputs.manifest-dir != ''
     working-directory: ${{ github.workspace }}\${{ inputs.vcpkg-subdir }}
     shell: powershell
     run: |
@@ -129,7 +124,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}"
   - name: vcpkg-dry-run-unix-manifest
-    if: runner.os != 'Windows' && inputs.manifest-dir != '' && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
+    if: runner.os != 'Windows' && inputs.manifest-dir != ''
     working-directory: ${{ github.workspace }}/${{ inputs.vcpkg-subdir }}
     shell: bash
     run: |
@@ -137,7 +132,7 @@ runs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}"
   - name: cache-vcpkg-archives
-    if: ${{ inputs.disable_cache != 'true' }} && inputs.github-binarycache != 'true' && inputs.github-binarycache != true
+    if: ${{ inputs.disable_cache != 'true' }}
     id: cache-vcpkg-archives
     uses: actions/cache@v4
     with:
@@ -145,14 +140,6 @@ runs:
       key: ${{ runner.os }}-${{ inputs.triplet }}-vcpkg-${{ hashFiles('${{ inputs.vcpkg-subdir }}/vcpkg_dry_run.txt') }}-${{ inputs.cache-key }}
     env:
       VCPKG_ROOT: "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}"
-  - name: Export GitHub Actions cache environment variables
-    if: (inputs.disable_cache != 'true' && inputs.disable_cache != true) &&  (inputs.github-binarycache == 'true' || inputs.github-binarycache == true)
-    uses: actions/github-script@v7
-    with:
-      script: |
-        core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-        core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-        core.exportVariable('VCPKG_BINARY_SOURCES', "clear;x-gha,readwrite");
   - name: build-vcpkg-win
     if: runner.os == 'Windows' && inputs.manifest-dir == ''
     shell: cmd


### PR DESCRIPTION
Remove `github-binarycache` option due to removal of `x-gha` option in `vcpkg-tool`. See https://github.com/microsoft/vcpkg-tool/pull/1662