### PR TITLE
Use x-write-nuget-packages-config option for hash file

### DIFF
--- a/.github/cmake_test/CMakeLists.txt
+++ b/.github/cmake_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...3.99)
 project(test_vcpkg_manifest)
 
 find_package(Boost REQUIRED COMPONENTS date_time)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,9 +38,14 @@ jobs:
       - name: cmake configure
         run: >
           cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 
-      - name: print vcpkg_dry_run.txt
+      - name: print vcpkg_dry_run.txt (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Get-Content "${{ github.workspace }}\\vcpkg\\vcpkg_dry_run.txt"
+      - name: print vcpkg_dry_run.txt (Unix)
+        if: runner.os != 'Windows'
         shell: bash
-        run: cat ${{ github.workspace }}/vcpkg/vcpkg_dry_run.txt
+        run: cat "${{ github.workspace }}/vcpkg/vcpkg_dry_run.txt"
 
   test-latest-vcpkg-release:
     runs-on: ${{ matrix.config.os }}
@@ -73,9 +78,14 @@ jobs:
       - name: cmake configure
         run: >
           cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 
-      - name: print vcpkg_dry_run.txt
+      - name: print vcpkg_dry_run.txt (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Get-Content "${{ github.workspace }}\\vcpkg\\vcpkg_dry_run.txt"
+      - name: print vcpkg_dry_run.txt (Unix)
+        if: runner.os != 'Windows'
         shell: bash
-        run: cat ${{ github.workspace }}/vcpkg/vcpkg_dry_run.txt
+        run: cat "${{ github.workspace }}/vcpkg/vcpkg_dry_run.txt"
 
   test-manifest:
     runs-on: ${{ matrix.config.os }}
@@ -104,6 +114,11 @@ jobs:
       - name: cmake configure
         run: >
           cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build
-      - name: print vcpkg_dry_run.txt
+      - name: print vcpkg_dry_run.txt (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Get-Content "${{ github.workspace }}\\vcpkg\\vcpkg_dry_run.txt"
+      - name: print vcpkg_dry_run.txt (Unix)
+        if: runner.os != 'Windows'
         shell: bash
-        run: cat ${{ github.workspace }}/vcpkg/vcpkg_dry_run.txt
+        run: cat "${{ github.workspace }}/vcpkg/vcpkg_dry_run.txt"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,9 @@ jobs:
       - name: cmake configure
         run: >
           cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 
+      - name: print vcpkg_dry_run.txt
+        shell: bash
+        run: cat ${{ github.workspace }}/vcpkg/vcpkg_dry_run.txt
 
   test-latest-vcpkg-release:
     runs-on: ${{ matrix.config.os }}
@@ -70,6 +73,9 @@ jobs:
       - name: cmake configure
         run: >
           cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build 
+      - name: print vcpkg_dry_run.txt
+        shell: bash
+        run: cat ${{ github.workspace }}/vcpkg/vcpkg_dry_run.txt
 
   test-manifest:
     runs-on: ${{ matrix.config.os }}
@@ -98,3 +104,6 @@ jobs:
       - name: cmake configure
         run: >
           cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -S ${{ github.workspace }}/.github/cmake_test -B cmake_build
+      - name: print vcpkg_dry_run.txt
+        shell: bash
+        run: cat ${{ github.workspace }}/vcpkg/vcpkg_dry_run.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         config:
         - os: ubuntu-22.04
           vcpkg_triplet: x64-linux-release
-        - os: macos-13
+        - os: macos-15-intel
           vcpkg_triplet: x64-osx-release
         - os: windows-2022
           vcpkg_triplet: x64-windows-release
@@ -56,7 +56,7 @@ jobs:
         config:
         - os: ubuntu-22.04
           vcpkg_triplet: x64-linux-release
-        - os: macos-13
+        - os: macos-15-intel
           vcpkg_triplet: x64-osx-release
         - os: windows-2022
           vcpkg_triplet: x64-windows-release
@@ -96,7 +96,7 @@ jobs:
         config:
         - os: ubuntu-22.04
           vcpkg_triplet: x64-linux-release
-        - os: macos-13
+        - os: macos-15-intel
           vcpkg_triplet: x64-osx-release
         - os: windows-2022
           vcpkg_triplet: x64-windows-release

--- a/action.yml
+++ b/action.yml
@@ -108,7 +108,7 @@ runs:
     working-directory: ${{ github.workspace }}\${{ inputs.vcpkg-subdir }}
     shell: powershell
     run: |
-      & "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}/vcpkg.exe" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} ${{ inputs.pkgs }} | Tee-Object -FilePath vcpkg_dry_run.txt
+      & "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}/vcpkg.exe" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} ${{ inputs.pkgs }} --x-write-nuget-packages-config=vcpkg_dry_run.txt
     env:
       VCPKG_ROOT: "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}"
   - name: vcpkg-dry-run-unix
@@ -116,7 +116,7 @@ runs:
     working-directory: ${{ github.workspace }}/${{ inputs.vcpkg-subdir }}
     shell: bash
     run: |
-      "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}/vcpkg" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} ${{ inputs.pkgs }} | tee vcpkg_dry_run.txt
+      "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}/vcpkg" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} ${{ inputs.pkgs }} --x-write-nuget-packages-config=vcpkg_dry_run.txt
     env:
       VCPKG_ROOT: "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}"
   - name: vcpkg-dry-run-win-manifest
@@ -124,7 +124,7 @@ runs:
     working-directory: ${{ github.workspace }}\${{ inputs.vcpkg-subdir }}
     shell: powershell
     run: |
-      & "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}/vcpkg.exe" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} --x-manifest-root=${{ inputs.manifest-dir }} --x-install-root=${{ github.workspace }}\${{ inputs.vcpkg-subdir }}\installed | Tee-Object -FilePath vcpkg_dry_run.txt
+      & "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}/vcpkg.exe" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} --x-manifest-root=${{ inputs.manifest-dir }} --x-install-root=${{ github.workspace }}\${{ inputs.vcpkg-subdir }}\installed --x-write-nuget-packages-config=vcpkg_dry_run.txt
     env:
       VCPKG_ROOT: "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}"
   - name: vcpkg-dry-run-unix-manifest
@@ -132,7 +132,7 @@ runs:
     working-directory: ${{ github.workspace }}/${{ inputs.vcpkg-subdir }}
     shell: bash
     run: |
-      "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}/vcpkg" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} --x-manifest-root=${{ inputs.manifest-dir }} --x-install-root=${{ github.workspace }}/${{ inputs.vcpkg-subdir }}/installed | tee vcpkg_dry_run.txt
+      "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}/vcpkg" install --dry-run --triplet ${{ inputs.triplet }} ${{ inputs.extra-args }} --x-manifest-root=${{ inputs.manifest-dir }} --x-install-root=${{ github.workspace }}/${{ inputs.vcpkg-subdir }}/installed --x-write-nuget-packages-config=vcpkg_dry_run.txt
     env:
       VCPKG_ROOT: "${{ github.workspace }}/${{ inputs.vcpkg-subdir }}"
   - name: cache-vcpkg-archives


### PR DESCRIPTION
This PR uses the output of the `--x-write-nuget-packages-config=` install option to generate the cache hash file instead of using the console output from the dry run. This provides a much more accurate cache hash value.

Also updates tests.